### PR TITLE
add failing test with io.Copy() and empty input

### DIFF
--- a/skein_test.go
+++ b/skein_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"testing"
 )
 
@@ -181,6 +182,20 @@ func TestNew(t *testing.T) {
 	for i, v := range testVectors {
 		h := New(v.outLen, v.args)
 		h.Write(v.input)
+		sum := fmt.Sprintf("%x", h.Sum(nil))
+		if sum != v.hexResult {
+			t.Errorf("%d: expected %s, got %s", i, v.hexResult, sum)
+		}
+	}
+}
+
+func TestCopyIo(t *testing.T) {
+	for i, v := range testVectors {
+		h := New(v.outLen, v.args)
+		r := bytes.NewReader(v.input)
+		if _, err := io.Copy(h, r); err != nil {
+			t.Error(err)
+		}
 		sum := fmt.Sprintf("%x", h.Sum(nil))
 		if sum != v.hexResult {
 			t.Errorf("%d: expected %s, got %s", i, v.hexResult, sum)


### PR DESCRIPTION
Hello and thanks for an useful package!

I discovered an issue and added a test case to demonstrate. This PR currently just holds this failing test.

The issue is that incorrect hash is calculated if given no data to work with, in combination with io.Copy()
(General usage learned from https://github.com/golang/go/wiki/Hashing)

So, this will fail:

```go
r := bytes.NewReader([]byte{})
h := skein.NewHash(64)
if _, err := io.Copy(h, r); err != nil {
	return nil, err
}
res := h.Sum(nil) // this gives wrong result
```

but, if the reader was non-empty, we get the correct checksum.

If we instead use Write(), we get correct checksum on empty data too:

```go
b := []byte{}
h := skein.NewHash(64)
h.Write(b)
res := h.Sum(nil) // this works!
```


```
$ go test -v
=== RUN   TestNew
--- PASS: TestNew (0.00s)
=== RUN   TestCopyIo
--- FAIL: TestCopyIo (0.00s)
	skein_test.go:202: 0: expected bc5b4c50925519c290cc634277ae3d6257212395cba733bbad37a4af0fa06af41fca7903d06564fea7a2d3730dbdb80c1f85562dfcc070334ea4d1d9e72cba7a, got dc8414cfd7d14500696250e43a613693ff4945e89718e6e8f1c7a5292555300a9e8c394edb5276a6881c98c6c51dfa569ea74f6894824495980bdc42cb800eaa
=== RUN   TestOutputReader
--- PASS: TestOutputReader (0.00s)
=== RUN   TestNewStream
--- PASS: TestNewStream (0.00s)
FAIL
exit status 1
FAIL	github.com/dchest/skein	0.006s
```